### PR TITLE
Add ADR for adopting Styled Components as a global styling strategy across CFIA projects

### DIFF
--- a/adr/009-styling-with-styled-components.md
+++ b/adr/009-styling-with-styled-components.md
@@ -1,0 +1,40 @@
+# ADR-009: Adopting Styled Components for CSS Styling Across CFIA Projects
+
+## Executive Summary
+
+This ADR documents the decision to adopt Styled Components over traditional CSS for styling across various projects at the Canadian Food Inspection Agency (CFIA). The decision is driven by the need for enhanced scalability, consistency, and development efficiency in styling approaches.
+
+## Context
+
+As projects at CFIA scale and evolve, maintaining a consistent and manageable styling approach becomes crucial. Traditional CSS, while familiar, poses challenges in large-scale applications due to its global scope and potential for naming conflicts.
+
+## Decision
+
+We have decided to adopt Styled Components across CFIA projects for the following reasons:
+1. **Component-Level Styling:** Enhances modularity and reusability, ensuring styles are encapsulated within their respective components.
+2. **Dynamic Styling:** Offers greater flexibility with prop-based style alterations, allowing for more dynamic and context-aware styling.
+3. **Reduced Naming Conflicts:** Automatically generated unique class names significantly reduce the risk of naming conflicts.
+4. **Easier Deletion of Unused Styles:** Styles are tightly coupled with components, making it straightforward to remove unused code and prevent style bloat.
+5. **Improved Developer Experience:** Integrates with modern development tools, offering features like syntax highlighting and style linting, thus enhancing the overall development process.
+
+**Link to Reference Materials:**
+- [Styled Components Official Documentation](https://styled-components.com/docs)
+
+## Alternatives Considered
+
+1. **Continuing with Traditional CSS:**
+   - Pros: Familiarity and simplicity.
+   - Cons: Scalability issues, potential naming conflicts, and less dynamic styling capabilities.
+
+2. **Other CSS-in-JS Libraries:**
+   - Pros: Similar benefits to Styled Components.
+   - Cons: Potential lack of feature parity or community support compared to Styled Components.
+
+## Consequences
+
+Adopting Styled Components is expected to streamline the development process, enhance the maintainability of codebases, and provide a more dynamic and scalable styling solution for CFIA's diverse range of projects.
+
+## References
+
+- Styled Components documentation and community discussions.
+- Comparative analysis of CSS styling approaches in modern web development.


### PR DESCRIPTION
Introduce an ADR documenting the adoption of Styled Components as the standard for CSS styling across all CFIA projects, outlining benefits, decision rationale, and comparisons with alternatives.

#92