### PR TITLE
Issue 108, Missing ADR-002 from the index

### DIFF
--- a/adr/index.md
+++ b/adr/index.md
@@ -6,6 +6,14 @@
 * [ADR-001 - Attachment: ADR Template](001-ailab-using-adr-template.en-ca.md)
   * Template used for ADRs in the AI-Lab.
 
+* [ADR-002: Database Structure](002-database-structure.md)
+
+* [ADR-002 - Attachment: Database Structure](002-database-structure-diagram.png)
+  * Graph explaining database management.
+
+* [ADR-002 - Attachment: Database Organization](002-database-structure-diagram-organization.png)
+  * Graph explaining database organization.
+
 * [ADR-003: Adopting PostgreSQL as the Database System](003-database-choice.md)
 
 * [ADR-004: Open Source Development](004-open-source-development.md)


### PR DESCRIPTION
Adding ADR-002 to the index.md

https://github.com/ai-cfia/dev-rel-docs/blob/d9b65e535301391039ffaeb352f4b6a05048bf90/adr/index.md?plain=1#L8